### PR TITLE
Bump Pillow to 11.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy==1.26.4
 opencv_python_headless==4.7.0.72
-Pillow==10.4.0
+Pillow==11.1.0
 scipy==1.14.1
 segmentation_models_pytorch==0.3.1
 scikit-image==0.21.0


### PR DESCRIPTION
Hello!

In my work with GrandQC (specifically with SVSs and on Mac), I noticed that `wsi_tis_detect.py` would sometimes save the tissue detection mask with mode I;16. This image is then loaded in `main.py` and a resize is attempted with resample filter LANCZOS on line 143: https://github.com/cpath-ukk/grandqc/blob/045b7a2d765ef0daa046609f93218312287a92d0/01_WSI_inference_OPENSLIDE_QC/main.py#L143

This would cause an error:

```
There was some problem with the slide. The error is: image has wrong mode
```

This is because of a known issue with Pillow 10.4.0 not supporting all resampling filters for images of mode I;16: https://github.com/python-pillow/Pillow/issues/8333.

This has been patched in Pillow 11.0.0 and higher: python-pillow/Pillow#8422

In my testing this resolves the issue on both my Mac and on an Ubuntu VM with CUDA, but please try it on your systems!